### PR TITLE
Update faraday_middleware dependency

### DIFF
--- a/slack.gemspec
+++ b/slack.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
 
   spec.add_runtime_dependency "faraday", "~> 0.11"
-  spec.add_runtime_dependency "faraday_middleware", "~> 0.10.0"
+  spec.add_runtime_dependency "faraday_middleware", "~> 0.12.0"
   spec.add_runtime_dependency "multi_json", ">= 1.0.3", "~> 1.0"
   spec.add_runtime_dependency "faye-websocket", "~> 0.10.6"
 end


### PR DESCRIPTION
The previous version had a CI vulnerability
https://snyk.io/vuln/SNYK-RUBY-FARADAYMIDDLEWARE-20334